### PR TITLE
Fix dialog creation for CajaWizard

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,9 +91,11 @@ class CajaWizardScreen(MDScreen):
         self.manager.current = "comprobante"
 
     def dialog(self, mensaje):
-        MDDialog(title="Atención", text=mensaje, buttons=[
-            MDFlatButton(text="OK", on_release=lambda x: self.dialog_inst.dismiss())
-        ])
+        self.dialog_inst = MDDialog(
+            title="Atención",
+            text=mensaje,
+            buttons=[MDFlatButton(text="OK", on_release=lambda x: self.dialog_inst.dismiss())]
+        )
         self.dialog_inst.open()
 
 class ComprobanteScreen(MDScreen):


### PR DESCRIPTION
## Summary
- ensure CajaWizardScreen assigns dialog instance before opening

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68630b4013248322949439e41d921bf7